### PR TITLE
Bump Dockerfile to use Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM alexellis2/raspistill:latest
+FROM resin/rpi-raspbian:stretch
 ENTRYPOINT []
-RUN apt-get update -qy && apt-get install -qy python
+
+RUN apt-get update -qy \
+  && apt-get install -qy python libraspberrypi-bin --no-install-recommends
+
 COPY . .
 
 VOLUME /var/image/


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

This moves the docker image to use Raspbian Stretch and moves the customisations I had applied in the previous image.

## Testing

Built on RPi3 but not tested with a camera.

To build:

```
docker build -t phototimer . 
```